### PR TITLE
Add error messaging for trying to create a game without having a game selected.

### DIFF
--- a/locales/en/client.json
+++ b/locales/en/client.json
@@ -798,6 +798,7 @@
   "ERROR.ErrorCloningWorld": "Error cloning world: {{error}}",
   "ERROR.ErrorRetrievingData": "Error retrieving data: {{error}}",
   "ERROR.FailedToCreateGame": "Failed to create game: {{error}}",
+  "ERROR.FailedToCreateGame.NoSystemSelected": "Failed to create game. Please select a system or world.",
   "ERROR.FailedToInstallSystem": "Failed to install system: {{error}}",
   "Errors occurred during upload, see below": "Errors occurred during upload, see below",
   "Errors uploading assets:": "Errors uploading assets:",


### PR DESCRIPTION
## Intent
This changeset adds a translation key for an error message that displays when a user attempts to create a new game through the "new game" modal without having a system selected.